### PR TITLE
Fixes params error

### DIFF
--- a/lib/rehearsal/middleware.rb
+++ b/lib/rehearsal/middleware.rb
@@ -79,8 +79,9 @@ module Rehearsal
         'REQUEST_URI' => url,
         'REQUEST_PATH' => uri.path,
         'PATH_INFO' => uri.path,
-        'QUERY_STRING' => uri.query
-      }).except('rack.request.form_hash')
+        'QUERY_STRING' => uri.query,
+        'rack.request.form_hash' => {}
+      })
 
       return objectify_response(process_request(request))
     end


### PR DESCRIPTION
- In commit: https://github.com/combinaut/rehearsal/commit/a29d222a84d25f15e7aabc82f124892f71030bf4 we prevented passing form params to the preview.
- but we cannot return nil, this is expecting a hash. This was causing an error whenever we tried to call request.params.
- returns empty hash rather than nil