### PR TITLE
Remove middleware injection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    combinaut_rehearsal (0.1.2)
+    combinaut_rehearsal (0.1.4)
       rails (>= 4.2)
 
 GEM
@@ -73,8 +73,8 @@ GEM
     crass (1.0.6)
     diff-lcs (1.3)
     erubi (1.9.0)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     loofah (2.4.0)
@@ -85,11 +85,13 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.8.2)
-    mimemagic (0.3.4)
-    mini_mime (1.0.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
+    mini_mime (1.1.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
-    nio4r (2.5.2)
+    nio4r (2.5.8)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     pry (0.10.4)
@@ -147,21 +149,21 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     slop (3.6.0)
-    sprockets (4.0.0)
+    sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    websocket-driver (0.7.1)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -176,4 +178,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.15.4
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Simply include the gem in your bundle, or `require` it by hand.
 
 ## Setup
 
+This gem is middleware and needs to be injected manually to ensure it sits in the correct order within your middleware stack.
+
+e.g. in application.rb:
+
+```
+config.middleware.use Rehearsal::Middleware
+
+```
+
+Rehearsal will need to be inserted before any middleware that modifies the URL.
+
 ### trigger
 
 The trigger defines a proc that enables the rehearsal mechanism for the request. Keep in mind the request has not yet

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This gem is middleware and needs to be injected manually to ensure it sits in th
 e.g. in application.rb:
 
 ```
-config.middleware.use Rehearsal::Middleware
+require 'rehearsal/middleware'
 
+config.middleware.use Rehearsal::Middleware
 ```
 
 Rehearsal will need to be inserted before any middleware that modifies the URL.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require 'rehearsal/middleware'
 config.middleware.use Rehearsal::Middleware
 ```
 
-Rehearsal will need to be inserted before any middleware that modifies the URL.
+Since Rehearsal makes additional calls down the middleware stack, typical usage is to insert it before any middleware that modifies incoming requests.
 
 ### trigger
 

--- a/lib/rehearsal.rb
+++ b/lib/rehearsal.rb
@@ -1,3 +1,2 @@
 require 'rails'
 require 'rehearsal/configuration'
-require 'rehearsal/railtie'

--- a/lib/rehearsal/railtie.rb
+++ b/lib/rehearsal/railtie.rb
@@ -1,9 +1,5 @@
 require 'rehearsal/middleware'
 
 module Rehearsal
-  class Railtie < Rails::Railtie
-    initializer "rehearsal.init" do |app|
-      app.config.middleware.use(Rehearsal::Middleware)
-    end
-  end
+  class Railtie < Rails::Railtie; end
 end

--- a/lib/rehearsal/railtie.rb
+++ b/lib/rehearsal/railtie.rb
@@ -1,5 +1,0 @@
-require 'rehearsal/middleware'
-
-module Rehearsal
-  class Railtie < Rails::Railtie; end
-end


### PR DESCRIPTION
- Having this gem self-inject itself into the middleware stack makes re-ordering the stack overly complicated.
- [x] removes the initialization code
- [x] update readme