### PR TITLE
fix(ci): add issues:write permission for stale PR workflow

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
### Changes

- Add `issues: write` permission to the stale PR workflow
- `actions/stale` uses the Issues API to add labels and comments on PRs, so `pull-requests: write` alone is insufficient

### Test plan

- [ ] Trigger via `workflow_dispatch` and verify stale PRs get labeled without permission errors

### Special Handling

- [ ] This PR requires user testing
- [ ] Include this PR in the changelog